### PR TITLE
Feature: Numeric assertions

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,13 @@ With special meanings dependant on type:
 * `contains(var $element)` - Asserts a string, array or map contains a given element
 * `doesNotContain(var $element)` - Asserts a string, array or map does not contain a given element
 
+For numbers:
+
+* `isGreaterThan(int|double $comparison)` - Asserts *value > comparison*
+* `isLessThan(int|double $comparison)` - Asserts *value < comparison*
+* `isBetween(int|double $start, int|double $end)` - Asserts *value >= start && value <= end*
+* `isCloseTo(int|double $comparison, int|double $tolerance)` - Asserts value is close (defined per tolerance)
+
 Transformations
 ---------------
 Values can be transformed prior to invoking assertions on them.

--- a/src/main/php/unittest/assert/NumericValue.class.php
+++ b/src/main/php/unittest/assert/NumericValue.class.php
@@ -1,0 +1,33 @@
+<?php namespace unittest\assert;
+
+class NumericValue extends Value {
+
+  public function isGreaterThan($comparison) {
+    return $this->is(new Match(
+      function($value) use($comparison) { return $value > $comparison; },
+      ['%s is not greater than'.$comparison, '%s is greater than '.$comparison]
+    ));
+  }
+
+  public function isLessThan($comparison) {
+    return $this->is(new Match(
+      function($value) use($comparison) { return $value < $comparison; },
+      ['%s is not less than'.$comparison, '%s is less than '.$comparison]
+    ));
+  }
+
+  public function isBetween($start, $end) {
+    return $this->is(new Match(
+      function($value) use($start, $end) { return $value >= $start && $value <= $end; },
+      ['%s is not between '.$start.' and '.$end, '%s is between '.$start.' and '.$end]
+    ));
+  }
+
+  public function isCloseTo($comparison, $tolerance) {
+    $within= '(within a tolerance of '.$tolerance.')';
+    return $this->is(new Match(
+      function($value) use($comparison, $tolerance) { return abs($value - $comparison) <= $tolerance; },
+      ['%s is not close to '.$comparison.' '.$within, '%s is close to '.$comparison.' '.$within]
+    ));
+  }
+}

--- a/src/main/php/unittest/assert/Value.class.php
+++ b/src/main/php/unittest/assert/Value.class.php
@@ -30,6 +30,8 @@ class Value extends \lang\Object {
       return new MapValue($value);
     } else if (is_string($value)) {
       return new StringValue($value);
+    } else if (is_int($value) || is_double($value)) {
+      return new NumericValue($value);
     } else {
       return new Value($value);
     }
@@ -203,6 +205,49 @@ class Value extends \lang\Object {
    */
   public function doesNotContain($element) {
     return $this->is(new NotPossible('does not contain anything'));
+  }
+
+  /**
+   * Assert this value is greater than a given comparison
+   *
+   * @param  int|double $comparison
+   * @return self
+   */
+  public function isGreaterThan($comparison) {
+    return $this->is(new NotPossible('cannot be greater than anything'));
+  }
+
+  /**
+   * Assert this value is less than a given comparison
+   *
+   * @param  int|double $comparison
+   * @return self
+   */
+  public function isLessThan($comparison) {
+    return $this->is(new NotPossible('cannot be less than anything'));
+  }
+
+  /**
+   * Assert this value is between start and end (both included)
+   *
+   * @param  int|double $start
+   * @param  int|double $end
+   * @return self
+   */
+  public function isBetween($start, $end) {
+    return $this->is(new NotPossible('cannot be between anything'));
+  }
+
+  /**
+   * Assert this value is close to a given comparison inside a given tolerance.
+   * If the difference is exactly the tolerance, this assertion is considered valid.
+   *
+   * @param  int|double $comparison
+   * @param  int|double $tolerance
+   * @return self
+   */
+  public function isCloseTo($comparison, $tolerance) {
+    return $this->is(new NotPossible('cannot be close to anything'));
   }
 
   /**

--- a/src/test/php/unittest/assert/unittest/NumberAssertionsTest.class.php
+++ b/src/test/php/unittest/assert/unittest/NumberAssertionsTest.class.php
@@ -1,0 +1,80 @@
+<?php namespace unittest\assert\unittest;
+
+use unittest\assert\Value;
+
+class NumberAssertionsTest extends TypeAssertionsTest {
+
+  /** @return var[][] */
+  protected function typeFixtures() { return [[0], [0.0], [1], [1.0]]; }
+
+  /** @return var[][] */
+  protected function lessThan1() { return [[0, -1, 0.0, 0.99999, PHP_INT_MIN]]; }
+
+  /** @return var[][] */
+  protected function moreThan1() { return [[2, 1.00001, PHP_INT_MAX]]; }
+
+  #[@test, @values('moreThan1')]
+  public function isGreaterThan1($value) {
+    $this->assertVerified(Value::of($value)->isGreaterThan(1));
+  }
+
+  #[@test, @values('lessThan1')]
+  public function is_not_LargerThan1($value) {
+    $this->assertUnverified(
+      ['/Failed to verify that .* is greater than 1/'],
+      Value::of($value)->isGreaterThan(1)
+    );
+  }
+
+  #[@test, @values('lessThan1')]
+  public function isLessThan1($value) {
+    $this->assertVerified(Value::of($value)->isLessThan(1));
+  }
+
+  #[@test, @values('moreThan1')]
+  public function is_not_LessThan1($value) {
+    $this->assertUnverified(
+      ['/Failed to verify that .* is less than 1/'],
+      Value::of($value)->isLessThan(1)
+    );
+  }
+
+  #[@test, @values([1, 1.0, 1.00001, 1.99999, 2])]
+  public function isBetween_1_and_2($value) {
+    $this->assertVerified(Value::of($value)->isBetween(1, 2));
+  }
+
+  #[@test, @values('lessThan1')]
+  public function values_less_than_1_are_notBetween_1_and_2($value) {
+    $this->assertUnverified(
+      ['/Failed to verify that .* is between 1 and 2/'],
+      Value::of($value)->isBetween(1, 2)
+    );
+  }
+
+  #[@test, @values('moreThan1')]
+  public function values_more_than_1_are_notBetween_0_and_1($value) {
+    $this->assertUnverified(
+      ['/Failed to verify that .* is between 0 and 1/'],
+      Value::of($value)->isBetween(0, 1)
+    );
+  }
+
+  #[@test, @values([1.0, 1.00001, 0.99999])]
+  public function isCloseTo1_using_decimals($value) {
+    $this->assertVerified(Value::of($value)->isCloseTo(1, 0.001));
+  }
+
+  #[@test, @values([1, 0, 2])]
+  public function isCloseTo1_using_integers($value) {
+    $this->assertVerified(Value::of($value)->isCloseTo(1, 1));
+  }
+
+  #[@test, @values([-1, 3])]
+  public function is_not_CloseTo1_using_integers($value) {
+    $this->assertUnverified(
+      ['/Failed to verify that .* is close to 1 \(within a tolerance of 1\)/'],
+      Value::of($value)->isCloseTo(1, 1)
+    );
+  }
+}


### PR DESCRIPTION
This pull request adds assertions for numbers:
- `isGreaterThan(int|double $comparison)` - Asserts _value > comparison_
- `isLessThan(int|double $comparison)` - Asserts _value < comparison_
- `isBetween(int|double $start, int|double $end)` - Asserts _value >= start && value <= end_
- `isCloseTo(int|double $comparison, int|double $tolerance)` - Asserts value is close (defined per tolerance)
