### PR TITLE
isEmpty()

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Generic assertions:
 
 With special meanings dependant on type:
 
+* `isEmpty()` - Asserts a string, array or map is empty
 * `hasSize(int $size)` - Asserts a string length, array or map size
 * `startsWith(var $element)` - Asserts a string or array contains the given element at its start
 * `endsWith(var $element)` - Asserts a string or array contains the given element at its end

--- a/src/main/php/unittest/assert/ArrayValue.class.php
+++ b/src/main/php/unittest/assert/ArrayValue.class.php
@@ -11,6 +11,13 @@ class ArrayValue extends Value {
     ));
   }
 
+  public function isEmpty() {
+    return $this->is(new Match(
+      function($value) { return empty($this->value); },
+      ['%s is not empty', '%s is empty']
+    ));
+  }
+
   public function contains($element) {
     $rep= Value::stringOf($element);
     return $this->is(new Match(

--- a/src/main/php/unittest/assert/MapValue.class.php
+++ b/src/main/php/unittest/assert/MapValue.class.php
@@ -11,6 +11,13 @@ class MapValue extends Value {
     ));
   }
 
+  public function isEmpty() {
+    return $this->is(new Match(
+      function($value) { return empty($this->value); },
+      ['%s is not empty', '%s is empty']
+    ));
+  }
+
   public function contains($element) {
     $rep= Value::stringOf($element);
     return $this->is(new Match(

--- a/src/main/php/unittest/assert/StringValue.class.php
+++ b/src/main/php/unittest/assert/StringValue.class.php
@@ -4,8 +4,15 @@ class StringValue extends Value {
 
   public function hasSize($size) {
     return $this->is(new Match(
-      function($value) use($size) { return strlen($value) === $size;; },
+      function($value) use($size) { return strlen($value) === $size; },
       ['%s does not have a length of '.$size, '%s has a length of '.$size]
+    ));
+  }
+
+  public function isEmpty() {
+    return $this->is(new Match(
+      function($value) { return 0 === strlen($value); },
+      ['%s is not empty', '%s is empty']
     ));
   }
 

--- a/src/main/php/unittest/assert/Value.class.php
+++ b/src/main/php/unittest/assert/Value.class.php
@@ -156,6 +156,15 @@ class Value extends \lang\Object {
   }
 
   /**
+   * Assert this value is empty
+   *
+   * @return self
+   */
+  public function isEmpty() {
+    return $this->is(new NotPossible('is empty'));
+  }
+
+  /**
    * Assert this value has a given size
    * 
    * @param  int $size

--- a/src/test/php/unittest/assert/unittest/ArrayAssertionsTest.class.php
+++ b/src/test/php/unittest/assert/unittest/ArrayAssertionsTest.class.php
@@ -8,6 +8,19 @@ class ArrayAssertionsTest extends TypeAssertionsTest {
   /** @return var[][] */
   protected function typeFixtures() { return [[['Fixture']]]; }
 
+  #[@test]
+  public function verify_is_empty() {
+    $this->assertVerified(Value::of([])->isEmpty());
+  }
+
+  #[@test, @values([[[1]], [[1, 2]]])]
+  public function is_empty($value) {
+    $this->assertUnverified(
+      ['/Failed to verify that .+ is empty/ms'],
+      Value::of($value)->isEmpty()
+    );
+  }
+
   #[@test, @values([[[]], [[1]], [[1, 2]]])]
   public function array_has_size($value) {
     $this->assertVerified(Value::of($value)->hasSize(sizeof($value)));

--- a/src/test/php/unittest/assert/unittest/MapAssertionsTest.class.php
+++ b/src/test/php/unittest/assert/unittest/MapAssertionsTest.class.php
@@ -32,6 +32,19 @@ class MapAssertionsTest extends TypeAssertionsTest {
     return array_merge($this->mapsNotContainingTest(), $this->mapsContainingTest());
   }
 
+  #[@test]
+  public function verify_is_empty() {
+    $this->assertVerified(Value::of([])->isEmpty());
+  }
+
+  #[@test, @values('mapsContainingTest')]
+  public function is_empty($value) {
+    $this->assertUnverified(
+      ['/Failed to verify that .+ is empty/ms'],
+      Value::of($value)->isEmpty()
+    );
+  }
+
   #[@test, @values('allMaps')]
   public function verify_has_size($value) {
     $this->assertVerified(Value::of($value)->hasSize(sizeof($value)));

--- a/src/test/php/unittest/assert/unittest/StringAssertionsTest.class.php
+++ b/src/test/php/unittest/assert/unittest/StringAssertionsTest.class.php
@@ -31,6 +31,19 @@ class StringAssertionsTest extends TypeAssertionsTest {
     ]);
   }
 
+  #[@test]
+  public function verify_is_empty() {
+    $this->assertVerified(Value::of('')->isEmpty());
+  }
+
+  #[@test, @values('stringsContainingTest')]
+  public function is_empty($value) {
+    $this->assertUnverified(
+      ['/Failed to verify that .+ is empty/'],
+      Value::of($value)->isEmpty()
+    );
+  }
+
   #[@test, @values([[0, ''], [4, 'test']])]
   public function hasSize($size, $value) {
     $this->assertVerified(Value::of($value)->hasSize($size));


### PR DESCRIPTION
This pull request implements a new `isEmpty()` assertion which works for arrays, string ands maps.

``` php
Assert::that('')->isEmpty();                   // OK
Assert::that([])->isEmpty();                   // OK

Assert::that('Not empty')->isEmpty();          // *** Assertion fails
Assert::that([1, 2, 3])->isEmpty();            // *** Assertion fails
Assert::that(['key' => 'value'])->isEmpty();   // *** Assertion fails
```

It gives a nicer wording than asserting `hasSize(0)`.
