### PR TITLE
Extract via closure

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ Extraction works directly on instances (using properties and `get`-prefixed as w
 $person= new Person(0xD00D, 'The Dude');
 Assert::that($person)->extracting('name')->isEqualTo('The Dude');
 
+$person= new Person(6100, 'Tim Tailor');
+Assert::that($person)->extracting(function($p) { return $p->name(); })->isEqualTo('Tim Tailor');
+
 $person= ['id' => 6100, 'name' => 'Test', 'age' => 42];
 Assert::that($person)->extracting(['name', 'age'])->isEqualTo(['Test', 42]);
 ```

--- a/src/main/php/unittest/assert/ArrayValue.class.php
+++ b/src/main/php/unittest/assert/ArrayValue.class.php
@@ -60,7 +60,7 @@ class ArrayValue extends Value {
   /**
    * Extract a given arg
    *
-   * @param  var $arg
+   * @param  string|string[]|function(var): var $arg
    * @return self
    */
   public function extracting($arg) {

--- a/src/main/php/unittest/assert/MapValue.class.php
+++ b/src/main/php/unittest/assert/MapValue.class.php
@@ -40,11 +40,13 @@ class MapValue extends Value {
   /**
    * Extract a given arg
    *
-   * @param  var $arg
+   * @param  string|string[]|function(var): var $arg
    * @return self
    */
   public function extracting($arg) {
-    if (is_array($arg)) {
+    if ($arg instanceof \Closure) {
+      return self::of($arg($this->value));
+    } else if (is_array($arg)) {
       $value= [];
       foreach ($arg as $key) {
         if (!array_key_exists($key, $this->value)) {

--- a/src/main/php/unittest/assert/Value.class.php
+++ b/src/main/php/unittest/assert/Value.class.php
@@ -218,19 +218,21 @@ class Value extends \lang\Object {
   /**
    * Extract a given arg
    *
-   * @param  var $arg
+   * @param  string|string[]|function(var): var $arg
    * @return self
    */
   public function extracting($arg) {
-    $extractor= new InstanceExtractor($this->value);
-    if (is_array($arg)) {
+    if ($arg instanceof \Closure) {
+      return self::of($arg($this->value));
+    } else if (is_array($arg)) {
+      $extractor= new InstanceExtractor($this->value);
       $value= [];
       foreach ($arg as $key) {
         $value[]= $extractor->extract($key);
       }
       return self::of($value);
     } else {
-      return self::of($extractor->extract($arg));
+      return self::of((new InstanceExtractor($this->value))->extract($arg));
     }
   }
 }

--- a/src/test/php/unittest/assert/unittest/ExtractingTest.class.php
+++ b/src/test/php/unittest/assert/unittest/ExtractingTest.class.php
@@ -52,4 +52,20 @@ class ExtractingTest extends AbstractAssertionsTest {
   public function extracting_from_array($person) {
     $this->assertVerified(Value::of([$person, $person])->extracting('name')->isEqualTo(['Test', 'Test']));
   }
+
+  #[@test]
+  public function extracting_from_instance_via_closure() {
+    $this->assertVerified(Value::of(new Person(1, 'Test', 42, ['name' => 'Test']))
+      ->extracting(function($person) { return $person->name(); })
+      ->isEqualTo('Test')
+    );
+  }
+
+  #[@test]
+  public function extracting_from_map_via_closure() {
+    $this->assertVerified(Value::of(['id' => 1, 'name' => 'Test'])
+      ->extracting(function($person) { return $person['name']; })
+      ->isEqualTo('Test')
+    );
+  }
 }


### PR DESCRIPTION
This pull request changes `extracting()` to also accept closures, which adds flexibility in handling and can provide a good performance benefit:

``` php
$person= new Person(6100, 'Tim Tailor');

// Current functionality, tests name(), getName() or $name reflectivey
Assert::that($person)->extracting('name')->isEqualTo('Tim Tailor');

// Newly added functionality
Assert::that($person)->extracting(function($p) { return $p->name(); })->isEqualTo('Tim Tailor');
```
