### PR TITLE
Custom assertions

### DIFF
--- a/src/main/php/unittest/assert/Assertion.class.php
+++ b/src/main/php/unittest/assert/Assertion.class.php
@@ -1,0 +1,33 @@
+<?php namespace unittest\assert;
+
+/**
+ * Base class for custom assertions. Overwrite this class as follows:
+ *
+ * ```php
+ * namespace example;
+ * use unittest\assert\Value;
+ *
+ * class TestCaseAssertion extends \unittest\assert\Assertion {
+ *
+ *   public static function hasName(Value $self, $name) {
+ *     return $self->isInstanceOf('unittest.TestCase')->extracting('name')->isEqualTo($name);
+ *   }
+ * }
+ * ```
+ *
+ * Inside your test class, import it:
+ *
+ * ```
+ * new import('example.TestCaseAssertion');
+ * ```
+ *
+ * You will then be able to write `Assert::that(...)->hasName('name')` in your test.
+ *
+ * @test  xp://unittest.assert.unittest.CustomAssertionsTest
+ */
+abstract class Assertion extends \lang\Object {
+
+  static function __import($scope) {
+    \xp::extensions(get_called_class(), $scope);
+  }
+}

--- a/src/test/php/unittest/assert/unittest/CustomAssertionsTest.class.php
+++ b/src/test/php/unittest/assert/unittest/CustomAssertionsTest.class.php
@@ -1,0 +1,12 @@
+<?php namespace unittest\assert\unittest;
+
+use unittest\assert\Value;
+new import('unittest.assert.unittest.TestCaseAssertion');
+
+class CustomAssertionsTest extends AbstractAssertionsTest {
+
+  #[@test]
+  public function hasName() {
+    $this->assertVerified(Value::of($this)->hasName($this->name));
+  }
+}

--- a/src/test/php/unittest/assert/unittest/TestCaseAssertion.class.php
+++ b/src/test/php/unittest/assert/unittest/TestCaseAssertion.class.php
@@ -1,0 +1,10 @@
+<?php namespace unittest\assert\unittest;
+
+use unittest\assert\Value;
+
+class TestCaseAssertion extends \unittest\assert\Assertion {
+  
+  public static function hasName(Value $self, $name) {
+    return $self->isInstanceOf('unittest.TestCase')->extracting('name')->isEqualTo($name);
+  }
+}


### PR DESCRIPTION
This pull request lets users add custom assertions. The implementation is based on extension methods.
## Implementing a custom assertion

You implement a custom assertion by extending from `unittest.Assertion`:

``` php
<?php namespace example\tests;

use unittest\assert\Value;

class TestCaseAssertions extends \unittest\assert\Assertion {

  public static function hasName(Value $self, $name) {
    return $self->isInstanceOf('unittest.TestCase')->extracting('name')->isEqualTo($name);
  }

  public static function isIgnored(Value $self, $name) {
    // TBI
  }
}
```
## Using a custom assertion

``` php
<?php namespace example\tests;

use unittest\assert\Assert;
use unittest\assert\Assertions;
new import('example.test.TestCaseAssertions');

#[@action(new Assertions())]
class CustomAssertionsTest extends \unittest\TestCase {

  #[@test]
  public function hasName() {
    Assert::that($this)->hasName($this->name);
  }
}
```
