### PR TITLE
Custom assertions

### DIFF
--- a/src/main/php/unittest/assert/Assertions.class.php
+++ b/src/main/php/unittest/assert/Assertions.class.php
@@ -14,6 +14,7 @@ class Assertions extends \lang\Object implements TestAction {
   const DECLARATION = '#[@action(new \unittest\assert\Assertions())]';
   const CURRENT = 0;
   protected static $verify= [];
+  public static $scope;
 
   /**
    * Creates a new verification
@@ -38,6 +39,7 @@ class Assertions extends \lang\Object implements TestAction {
    * @throws unittest.AssertionFailedError
    */
   public function beforeTest(TestCase $t) {
+    self::$scope= get_class($t);
     array_unshift(self::$verify, new Vector());
   }
 
@@ -53,5 +55,6 @@ class Assertions extends \lang\Object implements TestAction {
       $value->verify($failed);
     }
     $failed->raiseIf();
+    self::$scope= null;
   }
 }

--- a/src/main/php/unittest/assert/Value.class.php
+++ b/src/main/php/unittest/assert/Value.class.php
@@ -7,6 +7,15 @@ use unittest\AssertionFailedError;
 class Value extends \lang\Object {
   protected $value;
   protected $verify= [];
+  protected static $extensions= [];
+
+  static function __import($scope) {
+    $assertion= get_called_class();
+    self::$extensions[$assertion]= $assertion::type();
+  }
+
+  /** @return lang.Type */
+  protected static function type() { return Type::$VAR; }
 
   /**
    * Creates a new instance
@@ -31,6 +40,9 @@ class Value extends \lang\Object {
     } else if (is_string($value)) {
       return new StringValue($value);
     } else {
+      foreach (self::$extensions as $assertion => $type) {
+        if ($type->isInstance($value)) return new $assertion($value);
+      }
       return new Value($value);
     }
   }

--- a/src/main/php/unittest/assert/Value.class.php
+++ b/src/main/php/unittest/assert/Value.class.php
@@ -11,7 +11,7 @@ class Value extends \lang\Object {
 
   static function __import($scope) {
     $assertion= get_called_class();
-    self::$extensions[$assertion]= $assertion::type();
+    self::$extensions[$scope][$assertion]= $assertion::type();
   }
 
   /** @return lang.Type */
@@ -39,12 +39,12 @@ class Value extends \lang\Object {
       return new MapValue($value);
     } else if (is_string($value)) {
       return new StringValue($value);
-    } else {
-      foreach (self::$extensions as $assertion => $type) {
+    } else if (isset(self::$extensions[Assertions::$scope])) {
+      foreach (self::$extensions[Assertions::$scope] as $assertion => $type) {
         if ($type->isInstance($value)) return new $assertion($value);
       }
-      return new Value($value);
     }
+    return new Value($value);
   }
 
   /**

--- a/src/test/php/unittest/assert/unittest/CustomAssertionsTest.class.php
+++ b/src/test/php/unittest/assert/unittest/CustomAssertionsTest.class.php
@@ -1,0 +1,12 @@
+<?php namespace unittest\assert\unittest;
+
+use unittest\assert\Value;
+new import('unittest.assert.unittest.TestCaseAssertions');
+
+class CustomAssertionsTest extends AbstractAssertionsTest {
+
+  #[@test]
+  public function hasName() {
+    $this->assertVerified(Value::of($this)->hasName($this->name));
+  }
+}

--- a/src/test/php/unittest/assert/unittest/CustomAssertionsTest.class.php
+++ b/src/test/php/unittest/assert/unittest/CustomAssertionsTest.class.php
@@ -3,6 +3,7 @@
 use unittest\assert\Value;
 new import('unittest.assert.unittest.TestCaseAssertions');
 
+#[@action(new \unittest\assert\Assertions())]
 class CustomAssertionsTest extends AbstractAssertionsTest {
 
   #[@test]

--- a/src/test/php/unittest/assert/unittest/CustomAssertionsTest.class.php
+++ b/src/test/php/unittest/assert/unittest/CustomAssertionsTest.class.php
@@ -1,13 +1,22 @@
 <?php namespace unittest\assert\unittest;
 
 use unittest\assert\Value;
+use unittest\assert\Assertions;
 new import('unittest.assert.unittest.TestCaseAssertions');
 
-#[@action(new \unittest\assert\Assertions())]
+#[@action(new Assertions())]
 class CustomAssertionsTest extends AbstractAssertionsTest {
 
   #[@test]
   public function hasName() {
     $this->assertVerified(Value::of($this)->hasName($this->name));
+  }
+
+  #[@test]
+  public function isIgnored() {
+    $this->assertUnverified(
+      ['/Failed to verify that .* is ignored/'],
+      Value::of($this)->isIgnored()
+    );
   }
 }

--- a/src/test/php/unittest/assert/unittest/TestCaseAssertions.class.php
+++ b/src/test/php/unittest/assert/unittest/TestCaseAssertions.class.php
@@ -1,0 +1,13 @@
+<?php namespace unittest\assert\unittest;
+
+use lang\XPClass;
+
+class TestCaseAssertions extends \unittest\assert\Value {
+
+  /** @return lang.Type */
+  protected static function type() { return XPClass::forName('unittest.TestCase'); }
+
+  public function hasName($name) {
+    return $this->extracting('name')->isEqualTo($name);
+  }
+}

--- a/src/test/php/unittest/assert/unittest/TestCaseAssertions.class.php
+++ b/src/test/php/unittest/assert/unittest/TestCaseAssertions.class.php
@@ -1,6 +1,7 @@
 <?php namespace unittest\assert\unittest;
 
 use lang\XPClass;
+use unittest\assert\Match;
 
 class TestCaseAssertions extends \unittest\assert\Value {
 
@@ -9,5 +10,12 @@ class TestCaseAssertions extends \unittest\assert\Value {
 
   public function hasName($name) {
     return $this->extracting('name')->isEqualTo($name);
+  }
+
+  public function isIgnored() {
+    return $this->is(new Match(
+      function($value) { return $value->getClass()->getMethod($value->name)->hasAnnotation('ignore'); },
+      ['%s is not ignored', '%s is ignored']
+    ));
   }
 }


### PR DESCRIPTION
This pull request lets users add custom assertions. The implementation is based on extending the base class.
## Implementing a custom assertion

You implement a custom assertion by extending from `unittest.Value`:

``` php
<?php namespace example\tests;

use unittest\assert\Value;

class TestCaseAssertions extends \unittest\assert\Value {

  /** @return lang.Type */
  protected static function type() { return XPClass::forName('unittest.TestCase'); }

  public function hasName($name) {
    return $this->extracting('name')->isEqualTo($name);
  }

  public static function isIgnored() {
    // TBI
  }
}
```
## Using a custom assertion

``` php
<?php namespace example\tests;

use unittest\assert\Assert;
use unittest\assert\Assertions;
new import('example.test.TestCaseAssertions');

#[@action(new Assertions())]
class CustomAssertionsTest extends \unittest\TestCase {

  #[@test]
  public function hasName() {
    Assert::that($this)->hasName($this->name);
  }
}
```
